### PR TITLE
chore(ci): adopt docker-image-ci gold-standard reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,55 +1,40 @@
-# CI workflow for Docker image
 name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches:
+      - master
+      - main
   pull_request:
-    branches: [master, main]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  hadolint:
-    name: Hadolint
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Run Hadolint
-        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
-        continue-on-error: true  # Allow existing issues, report but don't block
-        with:
-          dockerfile: Dockerfile
-          failure-threshold: error
-
-  docker-build:
-    name: Docker Build Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      - name: Build (no push)
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          push: false
-          tags: test:latest
+  # Gold-standard container CI via the org meta-reusable: Dockerfile lint
+  # (+ shellcheck of setup/), YAML/Markdown/compose lint, validation-only
+  # image build with Trivy, secret scanning and dependency review — one
+  # call site. Push + cosign stay in docker-publish.yml.
+  docker-ci:
+    uses: netresearch/.github/.github/workflows/docker-image-ci.yml@main
+    permissions:
+      contents: read
+      packages: write
+      security-events: write
+      id-token: write
+      attestations: write
+      actions: read
+      pull-requests: write
+    with:
+      image-name: docker-validator-w3c
+      dockerfile: ./Dockerfile
+      lint-container: true
+      shell-scandirs: setup
+      lint-yaml: true
+      lint-markdown: true
+      lint-compose: true
+      compose-files: docker-compose.yml
+      enable-gitleaks: true
+      enable-codeql: false
+      enable-smoke-test: false
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,8 @@
+# Hadolint configuration.
+#
+# DL3008 (pin apt package versions) is ignored: this image builds on the
+# rolling debian:stable-slim base, where pinned apt versions rotate out of
+# the mirror and break the build. The RUN block already uses
+# --no-install-recommends and cleans apt lists.
+ignored:
+  - DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p /usr/share/man/man1/ && touch /usr/share/man/man1/sh.distrib.1.gz \
  && rm -rf /var/lib/apt/lists/* \
  && rm -f /var/cache/apt/*.bin
 
-ADD setup/ /
+COPY setup/ /
 RUN chmod u+x /*.sh \
  && /configure.sh \
  && ln -sf /dev/stdout /var/log/apache2/access.log \


### PR DESCRIPTION
Adopts the org container-CI gold standard by replacing the bespoke `ci.yml` (hadolint + build-test) with a single call to `netresearch/.github/.github/workflows/docker-image-ci.yml@main`.

## What the meta gate runs
- Dockerfile lint (hadolint) + shellcheck of `setup/`
- YAML, Markdown and `docker-compose.yml` lint
- Validation-only image build (`push: false`) with Trivy scan
- Gitleaks secret scan + dependency review

## Kept untouched
- `docker-publish.yml` — build + push + inline cosign (the meta gate does not push)
- `auto-merge-deps.yml` — org dependency auto-merge

## Inputs
| input | value |
|---|---|
| image-name | docker-validator-w3c |
| dockerfile | ./Dockerfile |
| shell-scandirs | setup |
| lint-yaml / lint-markdown / lint-compose | true |
| compose-files | docker-compose.yml |
| enable-gitleaks | true |
| enable-codeql / enable-smoke-test | false |

No `.hadolint.yaml` carried — the Dockerfile has no inline hadolint ignores.